### PR TITLE
chore: Run migrations as in-VPC ECS task and make RDS private

### DIFF
--- a/.github/workflows/_deploy-ecs-express.yml
+++ b/.github/workflows/_deploy-ecs-express.yml
@@ -74,28 +74,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run database migrations
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: |
-          echo "::group::Running Prisma migrations"
-          pnpm prisma migrate deploy
-          echo "::endgroup::"
-          echo "::notice::Migrations applied successfully"
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -128,6 +106,77 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Run Prisma migrations as a one-off ECS task inside the VPC, so it can
+      # reach the now-private RDS. Runs before the service is updated; a
+      # non-zero container exit code fails the deploy.
+      - name: Run database migrations (in-VPC ECS task)
+        env:
+          IMAGE: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository }}:${{ steps.meta.outputs.image_tag }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          EXECUTION_ROLE_ARN: ${{ secrets.ECS_EXECUTION_ROLE_ARN }}
+          TASK_ROLE_ARN: ${{ secrets.ECS_TASK_ROLE_ARN }}
+          MIGRATION_SUBNET: subnet-0582235ac8cb7e758
+          MIGRATION_SG: sg-04e2b769e3fa167a4
+          LOG_GROUP: /aws/ecs/default/mekapal-api-${{ inputs.environment == 'production' && 'prod' || 'dev' }}-migrate
+        run: |
+          set -euo pipefail
+
+          aws logs create-log-group --log-group-name "$LOG_GROUP" 2>/dev/null || true
+
+          # Register a one-off migration task def: new image, command override,
+          # DATABASE_URL passed straight through (private RDS, in-VPC).
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --family mekapal-api-${{ inputs.environment }}-migrate \
+            --requires-compatibilities FARGATE \
+            --network-mode awsvpc \
+            --cpu 256 --memory 512 \
+            --execution-role-arn "$EXECUTION_ROLE_ARN" \
+            --task-role-arn "$TASK_ROLE_ARN" \
+            --container-definitions "$(cat <<JSON
+          [
+            {
+              "name": "migrate",
+              "image": "${IMAGE}",
+              "essential": true,
+              "command": ["node_modules/.bin/prisma", "migrate", "deploy"],
+              "environment": [{ "name": "DATABASE_URL", "value": "${DATABASE_URL}" }],
+              "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                  "awslogs-group": "${LOG_GROUP}",
+                  "awslogs-region": "${AWS_REGION}",
+                  "awslogs-stream-prefix": "migrate"
+                }
+              }
+            }
+          ]
+          JSON
+          )" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $TASK_DEF_ARN"
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster default \
+            --launch-type FARGATE \
+            --task-definition "$TASK_DEF_ARN" \
+            --network-configuration "awsvpcConfiguration={subnets=[$MIGRATION_SUBNET],securityGroups=[$MIGRATION_SG],assignPublicIp=ENABLED}" \
+            --query 'tasks[0].taskArn' --output text)
+          echo "Started migration task $TASK_ARN"
+
+          aws ecs wait tasks-stopped --cluster default --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks --cluster default --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          STOP_REASON=$(aws ecs describe-tasks --cluster default --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' --output text)
+          echo "Migration task exit code: $EXIT_CODE (reason: $STOP_REASON)"
+
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Migration task failed (exit $EXIT_CODE). Aborting deploy."
+            exit 1
+          fi
+          echo "::notice::Migrations applied successfully"
 
       - name: Deploy to ECS Express Mode
         id: deploy-ecs

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,12 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
 
-# Copy prisma schema
+# Copy prisma schema and config (used by the migration RunTask)
 COPY prisma ./prisma
+COPY prisma.config.ts ./prisma.config.ts
 
-# Install all dependencies, generate Prisma client, then prune dev dependencies
+# Prisma CLI is a prod dependency so it survives prune; the migration RunTask
+# overrides the command to `prisma migrate deploy` from inside the VPC.
 RUN mkdir -p docs && \
     pnpm install --frozen-lockfile && \
     pnpm prisma generate && \

--- a/docs/03-rds-setup.md
+++ b/docs/03-rds-setup.md
@@ -8,35 +8,26 @@ Create two database instances:
 - `mekapal-dev` - Development database
 - `mekapal-prod` - Production database
 
-## 1. Create Security Group
+## 1. Security Group (private, SG-to-SG)
 
-First, create a security group that allows PostgreSQL access.
+RDS is **not publicly accessible**. The RDS SG allows 5432 **only from the ECS
+task SG** — no `0.0.0.0/0`. The app reaches RDS over the in-VPC private path.
 
-### Via AWS Console (Recommended)
-
-1. Go to **EC2 → Security Groups → Create security group**
-2. **Name**: `mekapal-rds-sg`
-3. **Description**: Security group for Mekapal RDS instances
-4. **Inbound rules**:
-   - Type: PostgreSQL
-   - Port: 5432
-   - Source: `0.0.0.0/0` (for development) or your IP range
-
-### Via CLI
+Current dev wiring:
+- RDS SG: `sg-0d327f9ff2faf8d1c`
+- ECS task SG: `sg-04e2b769e3fa167a4`
 
 ```bash
-# Create security group
-aws ec2 create-security-group \
-  --group-name mekapal-rds-sg \
-  --description "Security group for Mekapal RDS instances"
-
-# Add inbound rule (PostgreSQL)
+# Allow 5432 from the task SG only (no public CIDR)
 aws ec2 authorize-security-group-ingress \
-  --group-name mekapal-rds-sg \
-  --protocol tcp \
-  --port 5432 \
-  --cidr 0.0.0.0/0
+  --group-id sg-0d327f9ff2faf8d1c \
+  --protocol tcp --port 5432 \
+  --source-group sg-04e2b769e3fa167a4 \
+  --region us-east-1
 ```
+
+Do not add a `0.0.0.0/0` rule. For rare manual access use the EICE tunnel in
+[08-migrations.md](./08-migrations.md#4-rare-manual-db-access-private-rds).
 
 ## 2. Create Development Database
 
@@ -61,8 +52,8 @@ aws ec2 authorize-security-group-ingress \
 8. **Connectivity**:
    - VPC: Default VPC
    - Subnet group: Default
-   - Public access: **Yes** (required for local development access)
-   - VPC security group: Choose existing → `mekapal-rds-sg`
+   - Public access: **No** (private; reached in-VPC by the ECS task)
+   - VPC security group: Choose existing → the RDS SG
 9. **Database authentication**: Password authentication
 10. **Additional configuration**:
     - Initial database name: `mekapal`
@@ -85,7 +76,7 @@ aws rds create-db-instance \
   --storage-type gp2 \
   --db-name mekapal \
   --vpc-security-group-ids sg-xxxxxxxxx \
-  --publicly-accessible \
+  --no-publicly-accessible \
   --backup-retention-period 7 \
   --no-multi-az \
   --auto-minor-version-upgrade
@@ -101,7 +92,7 @@ Repeat the steps above with these differences:
 | Instance class | `db.t3.micro` | `db.t3.small` or larger |
 | Storage | 20 GB | 50 GB or more |
 | Storage autoscaling | Disabled | Enabled |
-| Public access | Yes | **No** (use VPC) |
+| Public access | **No** | **No** |
 | Multi-AZ | No | Yes (recommended) |
 | Backup retention | 7 days | 14+ days |
 
@@ -150,27 +141,20 @@ DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@mekapal-prod.xxxxxxxxx.us-east-
 
 ## 7. Test Connection
 
-```bash
-# Using psql
-psql -h mekapal-dev.xxxxxxxxx.us-east-1.rds.amazonaws.com -U postgres -d mekapal
+RDS is private; connect through the EICE tunnel (see
+[08-migrations.md](./08-migrations.md#4-rare-manual-db-access-private-rds)),
+then:
 
-# Or test with Prisma
-DATABASE_URL="postgresql://..." npx prisma db pull
+```bash
+psql -h localhost -U postgres -d mekapal
 ```
 
 ## Security Notes
 
-### For Development
-- Public access is enabled for convenience
-- Use strong passwords
-- Consider restricting security group to your IP
-
-### For Production
-- Disable public access
-- Use VPC peering or VPN for access
-- Enable Multi-AZ for high availability
-- Enable automated backups
-- Use AWS Secrets Manager for credentials
+- Public access **disabled** in both environments; access is in-VPC only.
+- RDS SG allows 5432 only from the ECS task SG (no public CIDR).
+- Use strong passwords; consider AWS Secrets Manager.
+- Production: Multi-AZ, deletion protection, and longer backup retention on.
 
 ## Summary
 

--- a/docs/06-ecs-express-setup.md
+++ b/docs/06-ecs-express-setup.md
@@ -155,7 +155,25 @@ aws logs tail /ecs/mekapal-api-dev --follow
 # Amazon ECS → Services → mekapal-api-dev → Logs
 ```
 
-## 8. Auto-scaling
+## 8. Migrations on deploy
+
+Migrations run as a one-off in-VPC ECS RunTask in the deploy workflow, before
+the service updates (private RDS is unreachable from the GitHub runner). See
+[08-migrations.md](./08-migrations.md). The container does **not** migrate on
+boot.
+
+## 9. Networking, ALB, and cost notes
+
+The Express gateway ALB (`ecs-express-gateway-alb-*`) is tagged
+`AmazonECSManaged: true` and the service has `resourceManagementType: ECS` with
+`availabilityZoneRebalancing: ENABLED` — **ECS owns the ALB, its AZ/subnet
+spread, and the per-AZ Elastic IPs**. Do not `set-subnets` or release those EIPs
+manually; ECS reconciles them back. There is no stable Express-native knob to
+reduce the AZ count today, so the ALB spans all default-VPC AZs.
+
+Cost log: see [13-networking-cost.md](./13-networking-cost.md).
+
+## 10. Auto-scaling
 
 ECS Express Mode configures CPU-based auto-scaling by default:
 - Minimum: 1 task (always running)

--- a/docs/08-migrations.md
+++ b/docs/08-migrations.md
@@ -4,76 +4,44 @@ Run Prisma migrations to set up the database schema.
 
 ## Overview
 
-Migrations are handled automatically by the GitHub Actions deploy workflow. The workflow runs `prisma migrate deploy` before deploying the new application version.
+RDS is **private** (not publicly accessible; ingress only from the ECS task SG).
+Migrations therefore run **inside the VPC**, not from the GitHub runner or a
+laptop.
 
-**Automatic (via GitHub Actions):**
-- Migrations run automatically on every deploy to `develop` or `main`
-- No manual intervention needed for normal deployments
+**Principle: schema changes go through Prisma migrations only — never manual
+`psql` / `ALTER TABLE`.** A migration file is the single source of truth; manual
+edits cause drift the next `migrate deploy` cannot reconcile.
 
-**Manual:**
-- Initial setup
-- Local development
-- Troubleshooting
+**Automatic (CI/CD):** every deploy to `develop` / `main` runs
+`prisma migrate deploy` as a one-off in-VPC ECS task before the service updates.
+No manual step for normal deployments.
 
-## 1. Run Migrations Locally
+## 1. How CI runs migrations (in-VPC ECS RunTask)
 
-The safest way is to run migrations from your local machine pointing to RDS.
+The deploy workflow (`.github/workflows/_deploy-ecs-express.yml`) runs migrations
+after pushing the image and before updating the service:
 
-### Development Database
+1. Register a one-off task def (`mekapal-api-<env>-migrate`) using the freshly
+   built image, command override `prisma migrate deploy`, `DATABASE_URL` from
+   the environment secret.
+2. `run-task` into the service subnet + task SG (`sg-04e2b769e3fa167a4`) so it
+   reaches private RDS; `aws ecs wait tasks-stopped`.
+3. If the container exit code is non-zero, the deploy **fails** before the
+   service is touched. A bad migration is a visible CI failure, not a runtime
+   crash-loop.
 
-```bash
-# Set the DATABASE_URL for development RDS
-export DATABASE_URL="postgresql://postgres:YOUR_PASSWORD@mekapal-dev.xxxxxxxxx.us-east-1.rds.amazonaws.com:5432/mekapal"
+We deliberately do **not** run migrations on container startup (would re-run on
+every boot and turn a bad migration into a crash-loop instead of a CI failure).
 
-# Run migrations
-pnpm prisma migrate deploy
-
-# Optionally, seed the database
-pnpm prisma db seed
-```
-
-### Production Database
-
-```bash
-# Set the DATABASE_URL for production RDS
-export DATABASE_URL="postgresql://postgres:YOUR_PASSWORD@mekapal-prod.xxxxxxxxx.us-east-1.rds.amazonaws.com:5432/mekapal"
-
-# Run migrations
-pnpm prisma migrate deploy
-```
+The `DATABASE_URL` secret is environment-specific (development vs production).
 
 ## 2. Verify Migrations
 
-```bash
-# Check migration status
-pnpm prisma migrate status
+`prisma migrate status` / `prisma studio` work locally only against a reachable
+DB — i.e. through the tunnel in section 4. In CI, the migrate task output (its
+exit code and CloudWatch logs) is the source of truth.
 
-# Open Prisma Studio to inspect data
-pnpm prisma studio
-```
-
-## 3. Automatic Migrations in CI/CD
-
-The deploy workflow (`.github/workflows/_deploy-apprunner.yml`) automatically runs migrations before deploying:
-
-```yaml
-- name: Run database migrations
-  env:
-    DATABASE_URL: ${{ secrets.DATABASE_URL }}
-  run: |
-    pnpm install --frozen-lockfile
-    pnpm prisma migrate deploy
-```
-
-**Flow:**
-1. Push to `develop` → runs migrations on dev DB → deploys to dev App Runner
-2. Push to `main` → runs migrations on prod DB → deploys to prod App Runner
-
-**Important:** The `DATABASE_URL` secret is environment-specific:
-- `development` environment uses dev database
-- `production` environment uses prod database
-
-## 4. Creating New Migrations
+## 3. Creating New Migrations
 
 When you change `prisma/schema.prisma`:
 
@@ -88,15 +56,36 @@ pnpm prisma migrate dev --name add_vehicle_status_field
 
 This creates a migration file in `prisma/migrations/`.
 
+## 4. Rare manual DB access (private RDS)
+
+RDS has no public IP, so connect through an **EC2 Instance Connect Endpoint**
+tunnel (~$0 standing cost; no NAT, no bastion instance). One-time: create an
+EICE in the VPC. Then:
+
+```bash
+# Tunnel localhost:5432 -> RDS through the EICE (keep running in a terminal)
+aws ec2-instance-connect open-tunnel \
+  --instance-connect-endpoint-id eice-xxxxxxxx \
+  --private-ip-address <rds-eni-private-ip> \
+  --remote-port 5432 --local-port 5432 --region us-east-1
+
+# In another terminal, point Prisma at the tunnel:
+export DATABASE_URL="postgresql://postgres:PASSWORD@localhost:5432/mekapal"
+pnpm prisma migrate status
+```
+
+For routine migrations use CI (section 1). Reserve the tunnel for debugging and
+`prisma studio`. Never `ALTER TABLE` by hand — use a migration.
+
 ## 5. Handling Migration Issues
 
 ### Reset Development Database
 
-If you need to reset the dev database:
+Pre-prod only, through the tunnel:
 
 ```bash
 # WARNING: This deletes all data!
-DATABASE_URL="postgresql://..." pnpm prisma migrate reset
+DATABASE_URL="postgresql://...@localhost:5432/mekapal" pnpm prisma migrate reset
 ```
 
 ### Failed Migration

--- a/docs/13-networking-cost.md
+++ b/docs/13-networking-cost.md
@@ -1,0 +1,71 @@
+# Networking & Cost Log
+
+Record of the networking posture and cost-reduction work on the dev (and only)
+environment. Account `946839355377`, region `us-east-1`, VPC
+`vpc-021b660a8ce126073`.
+
+## Cost investigation (the $6 → $88 jump)
+
+The bill jumped after the end-of-April 2026 move from App Runner to an **ECS
+Express Mode** stack. The surprise driver was **public IPv4 addresses**
+(`$0.005/hr ≈ $3.65/mo` each). Eight were in use:
+
+| Count | Resource | Notes |
+|------|----------|-------|
+| 6 | ECS-managed Express gateway ALB | one Elastic IP per AZ (us-east-1a–1f) |
+| 1 | ECS Fargate task ENI | the single app task |
+| 1 | RDS `mekapal-dev` | public instance with its own Elastic IP |
+
+8 × $3.65 ≈ **$29.72/mo** of the increase was public IPv4 alone.
+
+## Changes made
+
+### RDS made private + exposure closed
+
+- Added scoped ingress: 5432 on RDS SG `sg-0d327f9ff2faf8d1c` from the ECS task
+  SG `sg-04e2b769e3fa167a4` (rule `sgr-0bb5031d64872e857`).
+- Verified app↔DB over the in-VPC path (one-off ECS task, `select 1` → `DB_OK`).
+- `modify-db-instance --no-publicly-accessible --apply-immediately`.
+- Revoked the `0.0.0.0/0:5432` rule on the RDS SG.
+- RDS public IP gone; its Elastic IP `eipalloc-08549c0fc32090066` was released
+  automatically when the instance went private.
+
+Net: removed **1 public IP** (the RDS one) — ~$3.65/mo — and eliminated the open
+database to the internet.
+
+### Migration execution moved in-VPC
+
+Because RDS is now private, the GitHub runner can no longer reach it. Migrations
+now run as a **CI-triggered one-off ECS RunTask** inside the VPC (command
+override `prisma migrate deploy`, same subnet + task SG), gated before the
+service update. Chosen over running migrations on container startup: startup
+migration re-runs on every boot and turns a bad migration into a crash-loop
+instead of a visible CI failure. See [08-migrations.md](./08-migrations.md).
+
+### ALB AZ reduction — NOT done (ECS-managed)
+
+Goal was to shrink the ALB from 6 AZs to 2 and release 4 EIPs (~$14.60/mo). The
+ALB is tagged `AmazonECSManaged: true`; the service reports
+`resourceManagementType: ECS` and `availabilityZoneRebalancing: ENABLED`. ECS
+owns the ALB subnets and EIPs and reconciles manual changes back. There is no
+stable Express-native knob to set the AZ count today, so this was **not forced**.
+The 6 ALB EIPs (~$21.90/mo) remain until a supported option exists.
+
+## Result
+
+- Public IPs: **8 → 7** (removed RDS).
+- Realized saving: **~$3.65/mo** plus closing the public DB.
+- Remaining IPv4 cost: 6 ALB EIPs + 1 app task ENI = ~$25.55/mo, all ECS-managed.
+- The `$88 → ~$70` target depended on the ALB AZ reduction, which is blocked by
+  ECS Express Mode management; revisit if AWS exposes AZ control.
+
+## Reversal notes
+
+| Change | Reverse |
+|--------|---------|
+| SG-to-SG ingress | `revoke-security-group-ingress --group-id sg-0d327f9ff2faf8d1c --protocol tcp --port 5432 --source-group sg-04e2b769e3fa167a4` |
+| RDS private | `modify-db-instance --db-instance-identifier mekapal-dev --publicly-accessible --apply-immediately` |
+| Revoked public 5432 | `authorize-security-group-ingress --group-id sg-0d327f9ff2faf8d1c --protocol tcp --port 5432 --cidr 0.0.0.0/0` |
+
+Do not create a NAT Gateway to "fix" private RDS — it costs more than the IPs
+saved. The single app task keeps its public IP for image pulls.

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,10 +61,11 @@ Follow these guides in order:
 3. [RDS Setup](./03-rds-setup.md) - Create PostgreSQL databases
 4. [S3 Setup](./04-s3-setup.md) - Create storage buckets
 5. [Cognito Setup](./05-cognito-setup.md) - Create user pools
-6. [App Runner Setup](./06-app-runner-setup.md) - Create and configure services
+6. [ECS Express Setup](./06-ecs-express-setup.md) - Create and configure services
 7. [GitHub Secrets](./07-github-secrets.md) - Configure repository secrets
 8. [Migrations](./08-migrations.md) - Run database migrations
 9. [Verification](./09-verification.md) - Verify deployments
+13. [Networking & Cost](./13-networking-cost.md) - Private RDS, ALB, IPv4 cost log
 
 ## Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^3.2.0",
     "pg": "^8.20.0",
+    "prisma": "^7.8.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "stripe": "^20.3.0"
@@ -69,7 +70,6 @@
     "globals": "^17.0.0",
     "jest": "^30.2.0",
     "prettier": "^3.7.4",
-    "prisma": "^7.8.0",
     "prisma-erd-generator": "^2.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      prisma:
+        specifier: ^7.8.0
+        version: 7.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -141,9 +144,6 @@ importers:
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
-      prisma:
-        specifier: ^7.8.0
-        version: 7.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       prisma-erd-generator:
         specifier: ^2.4.2
         version: 2.4.2(@babel/core@7.28.5)(@babel/template@7.27.2)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/react@19.2.14)(puppeteer@23.11.1(typescript@5.9.3))
@@ -1159,7 +1159,7 @@ packages:
       rxjs: ^7.1.0
 
   '@nestjs/core@11.1.11':
-    resolution: {integrity: sha512-H9i+zT3RvHi7tDc+lCmWHJ3ustXveABCr+Vcpl96dNOxgmrx4elQSTC4W93Mlav2opfLV+p0UTHY6L+bpUA4zA==}
+    resolution: {integrity: sha1-nq5+SIxFpENoVWfBVVrjzXOdEv4=}
     engines: {node: '>= 20'}
     peerDependencies:
       '@nestjs/common': ^11.0.0
@@ -1743,7 +1743,7 @@ packages:
     os: [win32]
 
   '@swc/core@1.15.8':
-    resolution: {integrity: sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==}
+    resolution: {integrity: sha1-gYq+qxzFdUanc7Ed7E7dirJq5oc=}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -12,6 +12,7 @@ describe('main.ts', () => {
     setGlobalPrefix: jest.Mock;
     listen: jest.Mock;
     useGlobalPipes: jest.Mock;
+    enableCors: jest.Mock;
   };
   let mockConfigService: {
     get: jest.Mock;
@@ -19,12 +20,14 @@ describe('main.ts', () => {
 
   // Helper function to set config values
   const setConfigValues = (overrides: { PORT?: number | string | null }) => {
-    mockConfigService.get.mockImplementation((key: string) => {
-      if (key === 'PORT' && overrides.PORT !== undefined) return overrides.PORT;
-      // Use default values
-      if (key === 'PORT') return 3001;
-      return undefined;
-    });
+    mockConfigService.get.mockImplementation(
+      (key: string, defaultValue?: unknown) => {
+        if (key === 'PORT' && overrides.PORT !== undefined)
+          return overrides.PORT;
+        if (key === 'PORT') return 3001;
+        return defaultValue;
+      },
+    );
   };
 
   beforeEach(() => {
@@ -36,13 +39,14 @@ describe('main.ts', () => {
       setGlobalPrefix: jest.fn(),
       listen: jest.fn(),
       useGlobalPipes: jest.fn(),
+      enableCors: jest.fn(),
     };
 
     // Mock ConfigService with safe defaults
     mockConfigService = {
-      get: jest.fn((key: string) => {
+      get: jest.fn((key: string, defaultValue?: unknown) => {
         if (key === 'PORT') return 3001;
-        return undefined;
+        return defaultValue;
       }),
     };
 
@@ -269,11 +273,13 @@ describe('main.ts', () => {
         executionOrder.push('get ConfigService');
         return mockConfigService;
       });
-      mockConfigService.get.mockImplementation((key: string) => {
-        executionOrder.push(`get ${key}`);
-        if (key === 'PORT') return 3001;
-        return undefined;
-      });
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultValue?: unknown) => {
+          executionOrder.push(`get ${key}`);
+          if (key === 'PORT') return 3001;
+          return defaultValue;
+        },
+      );
       mockApp.useGlobalPipes.mockImplementation(() => {
         executionOrder.push('useGlobalPipes');
       });
@@ -292,6 +298,7 @@ describe('main.ts', () => {
       expect(executionOrder).toEqual([
         'get ConfigService',
         'get PORT',
+        'get CORS_ORIGIN',
         'setGlobalPrefix',
         'useGlobalPipes',
         'listen',


### PR DESCRIPTION
## Description

- **What is the purpose of this pull request?** Close the public exposure of the RDS database and rework how migrations run during deploy so they still work against a private database. Also reduce AWS public-IPv4 cost where possible.
- **What changes have been made?**
  - Move `prisma migrate deploy` off the GitHub runner into a one-off in-VPC Fargate task triggered by the deploy workflow (so it can reach a private RDS). The step gates the deploy: a non-zero exit aborts before the service is updated.
  - Revert the interim startup-entrypoint migration approach (removed `docker-entrypoint.sh`, restored `CMD`); keep the Prisma CLI in prod dependencies so the task command override works.
  - Make RDS private (`PubliclyAccessible=false`), scope DB access to the app's security group, and remove the `0.0.0.0/0` ingress rule (applied live).
  - Document the cost investigation ($6→$88) and networking changes in `docs/13-networking-cost.md`; update `03-rds-setup.md`, `06-ecs-express-setup.md`, `08-migrations.md`, and the docs README.
- **What issue does this fix?** N/A — triggered by an AWS bill investigation; the public database was both a cost and a security concern.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor or improvement
- [ ] Test enhancement
- [x] Documentation update

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting rules have been followed
- [ ] Corresponding tests have been added and/or updated
- [x] Documentation has been updated (if applicable)
- [x] The PR title is clear and uses proper formatting
- [x] Commits are clean, with descriptive messages

## How Has This Been Tested?

- DB connectivity to the now-private RDS was verified live via a one-off in-VPC ECS task running `select 1` (exit 0) — before going private, after `--no-publicly-accessible`, and after revoking the `0.0.0.0/0` rule.
- The deploy workflow YAML was validated, and the run-task command-override + in-VPC connectivity pattern was exercised against the real cluster/subnet/SG.
- The new in-VPC migration step is exercised end-to-end on the first deploy after merge — watch the "Run database migrations (in-VPC ECS task)" step in the Actions run; on failure it aborts before the service is updated.

## Further Comments

The deployed workflow on `develop` is still the old one until this merges, and RDS is already private — so the first deploy after merge uses the new in-VPC migration step (intended; do not deploy the old workflow against the private DB). The ALB AZ reduction (the larger ~$14.6/mo saving) is blocked by ECS Express
Mode managing the ALB subnets/EIPs; realized saving here is ~$3.65/mo plus the security fix. Details in `docs/13-networking-cost.md`.
